### PR TITLE
Refactor tab state management and sync window edited state

### DIFF
--- a/crates/opennote-desktop/src/views/workspace/actions.rs
+++ b/crates/opennote-desktop/src/views/workspace/actions.rs
@@ -222,7 +222,7 @@ impl Workspace {
     pub fn close_active_tab(
         &mut self,
         _action: &CloseActiveTab,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let states = get_states(cx);
@@ -232,7 +232,7 @@ impl Workspace {
 
         let _ = active_pane.update(cx, |this, cx| {
             if let Some(selected_block_id) = this.selected_block_id {
-                this.close_tab(&selected_block_id, cx);
+                this.close_tab(&selected_block_id, cx, window);
             }
         });
     }

--- a/crates/opennote-desktop/src/views/workspace/mod.rs
+++ b/crates/opennote-desktop/src/views/workspace/mod.rs
@@ -79,7 +79,7 @@ impl Workspace {
             Theme::sync_system_appearance(Some(window), cx);
         }));
 
-        _subscriptions.push(cx.observe_in(&pane, window, |this, entity, window, cx| {
+        _subscriptions.push(cx.observe_in(&pane, window, |this, _entity, window, cx| {
             this.update_window_title(window, cx);
         }));
 

--- a/crates/opennote-desktop/src/widgets/editor/mod.rs
+++ b/crates/opennote-desktop/src/widgets/editor/mod.rs
@@ -105,9 +105,8 @@ impl Editor {
         cx.defer(move |cx| {
             let _ = pane.update(cx, |this, _cx| {
                 if let Some(existing_block_id) = &block_id {
-                    if let Some(tab_state) = this.opened_block_states.get_mut(&existing_block_id) {
-                        tab_state.unsaved_content = Some(existing_block_content);
-                    }
+                    this.opened_tab_states
+                        .store_unsaved_content(existing_block_id, existing_block_content);
                 }
             });
         });
@@ -149,8 +148,8 @@ impl Editor {
         let unsaved_content = self
             .pane
             .update(cx, |this, _cx| {
-                if let Some(tab_state) = this.opened_block_states.get_mut(&block.id) {
-                    return tab_state.unsaved_content.take();
+                if let Some(unsaved) = this.opened_tab_states.take_tab_content(&block.id) {
+                    return Some(unsaved);
                 }
 
                 None

--- a/crates/opennote-desktop/src/widgets/editor/observations.rs
+++ b/crates/opennote-desktop/src/widgets/editor/observations.rs
@@ -13,7 +13,7 @@ use crate::{
             unique_notifications::ChunkBlockNotification,
         },
     },
-    widgets::{editor::Editor, pane::tab::TabState},
+    widgets::editor::Editor,
 };
 
 pub fn observe_theme_change(
@@ -82,5 +82,8 @@ pub fn observe_chunk_block(
     }
 
     // Alter the tab's save state to true
-    TabState::set_save_state(cx, pane_clone.clone(), block.id, true);
+    let _ = pane_clone.update(cx, |this, _cx| {
+        this.opened_tab_states
+            .update_tab_save_state(window, &block.id, true);
+    });
 }

--- a/crates/opennote-desktop/src/widgets/editor/subscriptions.rs
+++ b/crates/opennote-desktop/src/widgets/editor/subscriptions.rs
@@ -2,13 +2,13 @@ use gpui::{Context, Entity};
 
 use opennote_velotype::editor::EditorEvent;
 
-use crate::widgets::{editor::Editor, pane::tab::TabState};
+use crate::widgets::editor::Editor;
 
 pub fn subscribe_editor_events(
     view: &mut Editor,
     _state: &Entity<opennote_velotype::editor::Editor>,
     event: &EditorEvent,
-    _window: &mut gpui::Window,
+    window: &mut gpui::Window,
     cx: &mut Context<'_, Editor>,
 ) {
     let pane_clone = view.pane.clone();
@@ -19,7 +19,10 @@ pub fn subscribe_editor_events(
                 return;
             };
 
-            TabState::set_save_state(cx, pane_clone.clone(), block.id, false);
+            let _ = pane_clone.update(cx, |this, _cx| {
+                this.opened_tab_states
+                    .update_tab_save_state(window, &block.id, false);
+            });
         }
     }
 }

--- a/crates/opennote-desktop/src/widgets/pane/mod.rs
+++ b/crates/opennote-desktop/src/widgets/pane/mod.rs
@@ -1,8 +1,6 @@
 pub mod helpers;
 pub mod tab;
 
-use std::collections::HashMap;
-
 use gpui::{
     Action, Context, Div, Entity, FocusHandle, Focusable, Render, SharedString, Subscription,
     Window, div, prelude::*, px,
@@ -14,16 +12,18 @@ use gpui_component::{
 };
 use uuid::Uuid;
 
-use crate::globals::{helpers::get_language_profile, states::helpers::get_states};
-use crate::key_mappings::{
-    helpers::get_keystrokes_as_shared_string,
-    mappings::{CreateOneBlock, OpenNewWindow, ToggleCommandBar, ToggleSearchBar},
-};
-use crate::libs::tabs::tab_bar::TabBar;
-use crate::widgets::{
-    editor::Editor,
-    pane::tab::{TabState, create_tab_bar_for_blocks},
-    sidebar::{OpenNoteSidebar, OpenNoteSidebarEvent},
+use crate::{
+    globals::{helpers::get_language_profile, states::helpers::get_states},
+    key_mappings::{
+        helpers::get_keystrokes_as_shared_string,
+        mappings::{CreateOneBlock, OpenNewWindow, ToggleCommandBar, ToggleSearchBar},
+    },
+    libs::tabs::tab_bar::TabBar,
+    widgets::{
+        editor::Editor,
+        pane::tab::{TabStates, create_tab_bar_for_blocks},
+        sidebar::{OpenNoteSidebar, OpenNoteSidebarEvent},
+    },
 };
 
 /// A container for 0 to many items that are open in the workspace.
@@ -35,7 +35,7 @@ pub struct Pane {
 
     pub selected_block_id: Option<Uuid>,
     pub opened_block_ids: Vec<Uuid>,
-    pub opened_block_states: HashMap<Uuid, TabState>,
+    pub opened_tab_states: TabStates,
     /// The string that will highlighted in the editor
     pub search_string: Option<SharedString>,
 
@@ -53,21 +53,25 @@ impl Pane {
     ) -> Self {
         let mut _subscriptions = Vec::new();
 
-        _subscriptions.push(cx.subscribe(&sidebar, move |this, _entity, event, cx| {
-            if !this.has_opened_blocks() {
-                return;
-            };
+        _subscriptions.push(cx.subscribe_in(
+            &sidebar,
+            window,
+            move |this, _entity, event, window, cx| {
+                if !this.has_opened_blocks() {
+                    return;
+                }
 
-            match event {
-                OpenNoteSidebarEvent::BlocksDeleted(block_ids) => {
-                    for id in block_ids {
-                        if this.opened_block_ids.contains(id) {
-                            this.close_tab(id, cx);
+                match event {
+                    OpenNoteSidebarEvent::BlocksDeleted(block_ids) => {
+                        for id in block_ids {
+                            if this.opened_block_ids.contains(id) {
+                                this.close_tab(id, cx, window);
+                            }
                         }
                     }
                 }
-            }
-        }));
+            },
+        ));
 
         let pane_ref = cx.weak_entity();
 
@@ -78,12 +82,17 @@ impl Pane {
             search_string: None,
             editor: cx.new(|cx| Editor::new(cx, window, pane_ref)),
             opened_block_ids: Vec::new(),
-            opened_block_states: HashMap::new(),
+            opened_tab_states: TabStates::new(),
             _subscriptions,
         }
     }
 
-    pub(crate) fn close_tab(&mut self, block_id: &Uuid, cx: &mut Context<Self>) {
+    pub(crate) fn close_tab(
+        &mut self,
+        block_id: &Uuid,
+        cx: &mut Context<Self>,
+        window: &mut gpui::Window,
+    ) {
         // if we have multiple tabs openning
         if self.opened_block_ids.len() > 1 {
             // Remove the closed block from the openned blocks,
@@ -97,7 +106,7 @@ impl Pane {
             }
 
             self.opened_block_ids.remove(removed_index as usize);
-            self.opened_block_states.remove(block_id);
+            self.opened_tab_states.remove_tab_state(block_id, window);
 
             // Move the focus to the previous tab / block
             if let Some(selected_block_id) = &self.selected_block_id {
@@ -129,7 +138,7 @@ impl Pane {
         // if we only have 1 tab openning
         if self.opened_block_ids.len() == 1 {
             self.opened_block_ids.clear();
-            self.opened_block_states.clear();
+            self.opened_tab_states.remove_all_tab_state(window);
             self.selected_block_id = None;
 
             cx.notify();
@@ -157,12 +166,7 @@ impl Pane {
         }
 
         self.opened_block_ids.push(block_id);
-        self.opened_block_states.insert(
-            block_id,
-            TabState {
-                ..Default::default()
-            },
-        );
+        self.opened_tab_states.create_tab_state(&block_id);
         self.selected_block_id = Some(block_id);
         cx.notify();
     }
@@ -311,7 +315,7 @@ impl Render for Pane {
             pane_id,
             &self.opened_block_ids,
             self.selected_block_id,
-            &self.opened_block_states,
+            &self.opened_tab_states,
         );
 
         // Open editor only when there is an active block

--- a/crates/opennote-desktop/src/widgets/pane/tab.rs
+++ b/crates/opennote-desktop/src/widgets/pane/tab.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use gpui::{App, Context, prelude::*};
+use gpui::{Context, Window, prelude::*};
 use gpui::{ElementId, SharedString, WeakEntity};
 use gpui_component::button::{Button, ButtonRounded, ButtonVariants};
 use gpui_component::{IconName, Selectable, Sizable};
@@ -33,15 +33,84 @@ impl Default for TabState {
     }
 }
 
-impl TabState {
-    pub fn set_save_state(cx: &mut App, pane: WeakEntity<Pane>, block_id: Uuid, has_saved: bool) {
-        let _ = pane.update(cx, |this, _cx| {
-            let Some(tab_state) = this.opened_block_states.get_mut(&block_id) else {
-                return;
-            };
+/// Key: block_id
+/// Value: TabState
+pub struct TabStates(HashMap<Uuid, TabState>);
 
+impl TabStates {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub fn does_tab_exist(&self, block_id: &Uuid) -> bool {
+        self.0.contains_key(block_id)
+    }
+
+    /// This will return a false when the tab does not exist.
+    pub fn has_tab_saved(&self, block_id: &Uuid) -> bool {
+        match self.0.get(block_id) {
+            Some(result) => result.has_saved,
+            None => false,
+        }
+    }
+
+    pub fn create_tab_state(&mut self, block_id: &Uuid) {
+        self.0.insert(
+            *block_id,
+            TabState {
+                ..Default::default()
+            },
+        );
+    }
+
+    pub fn update_tab_save_state(&mut self, window: &mut Window, block_id: &Uuid, has_saved: bool) {
+        if let Some(tab_state) = self.0.get_mut(block_id) {
             tab_state.has_saved = has_saved;
-        });
+
+            // As long as there's one tab remains edited,
+            // the corresponding window should also remain edited.
+            if !tab_state.has_saved {
+                window.set_window_edited(true);
+            }
+        }
+
+        self.cleanup_window_edited_state(window);
+    }
+
+    /// Check if the window is good to remove the edited state.
+    fn cleanup_window_edited_state(&self, window: &mut Window) {
+        let has_unsaved_contents = self
+            .0
+            .iter()
+            .any(|(_block_id, tab_state)| !tab_state.has_saved);
+
+        if !has_unsaved_contents {
+            window.set_window_edited(false);
+        }
+    }
+
+    pub fn store_unsaved_content(&mut self, block_id: &Uuid, unsaved: SharedString) {
+        if let Some(tab_state) = self.0.get_mut(&block_id) {
+            tab_state.unsaved_content = Some(unsaved);
+        }
+    }
+
+    pub fn take_tab_content(&mut self, block_id: &Uuid) -> Option<SharedString> {
+        if let Some(tab_state) = self.0.get_mut(block_id) {
+            return tab_state.unsaved_content.take();
+        }
+
+        None
+    }
+
+    pub fn remove_tab_state(&mut self, block_id: &Uuid, window: &mut Window) {
+        self.0.remove(block_id);
+        self.cleanup_window_edited_state(window);
+    }
+
+    pub fn remove_all_tab_state(&mut self, window: &mut Window) {
+        self.0.clear();
+        self.cleanup_window_edited_state(window);
     }
 }
 
@@ -51,16 +120,17 @@ pub fn create_tab_bar_for_blocks(
     pane_id: Uuid,
     opened_block_ids: &Vec<Uuid>,
     selected_block_id: Option<Uuid>,
-    opened_block_states: &HashMap<Uuid, TabState>,
+    openned_tab_states: &TabStates,
 ) -> TabBar {
     let tabs = TabBar::new("tabs").children(opened_block_ids.iter().map(|id| {
         let id = id.clone();
         let mut selected = false;
 
-        // Get the save status of the active block
-        let Some(tab_state) = opened_block_states.get(&id) else {
+        // If we can't get the tab state, that means the application is not synced.
+        // Then we probably need to quit the app.
+        if !openned_tab_states.does_tab_exist(&id) {
             panic!("Opened blocks' states dis-synced. Aborted")
-        };
+        }
 
         // The active block is the focused block
         if let Some(selected_block_id) = &selected_block_id {
@@ -94,8 +164,8 @@ pub fn create_tab_bar_for_blocks(
                     .ghost()
                     .xsmall()
                     .rounded(ButtonRounded::Medium)
-                    .on_click(cx.listener(move |view, _, _, cx| {
-                        view.close_tab(&id, cx);
+                    .on_click(cx.listener(move |view, _, window, cx| {
+                        view.close_tab(&id, cx, window);
                         cx.stop_propagation();
                     })),
             )
@@ -111,11 +181,12 @@ pub fn create_tab_bar_for_blocks(
                 move |value: &DraggedItem, _point, _window, app| app.new(|_| value.clone()),
             );
 
-        if !tab_state.has_saved {
+        if !openned_tab_states.has_tab_saved(&id) {
             tab = tab.prefix("⏺");
         }
 
         tab
     }));
+
     tabs
 }


### PR DESCRIPTION
Replace `Pane::opened_block_states` with a `TabStates` wrapper that encapsulates tab state operations. Propagate `Window` into tab close/save updates so unsaved tabs mark the window as edited and clearing/saving all tabs clears the edited state.