### PR TITLE
Improve workspace focus handling

### DIFF
--- a/crates/opennote-desktop/src/views/workspace/actions.rs
+++ b/crates/opennote-desktop/src/views/workspace/actions.rs
@@ -44,15 +44,17 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.sidebar.update(cx, |this, cx| {
+        self.sidebar.clone().update(cx, |this, cx| {
             this.toggle(cx);
 
             // Manually shift the focus, otherwise it won't just focus automatically
             if !this.is_toggled() {
-                window.focus(&self.focus_handle(cx));
+                self.return_focus(window);
             }
 
             if this.is_toggled() {
+                self.advance_focus(window, cx);
+
                 let states = get_states(cx);
                 let active_server =
                     states.get_active_server_name(window.window_handle().window_id());
@@ -72,15 +74,17 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.search_bar.update(cx, |this, cx| {
+        self.search_bar.clone().update(cx, |this, cx| {
             this.is_toggled = !this.is_toggled;
 
             // Manually shift the focus, otherwise it won't just focus automatically
             if !this.is_toggled {
-                window.focus(&self.focus_handle(cx));
+                self.return_focus(window);
             }
 
             if this.is_toggled {
+                self.advance_focus(window, cx);
+
                 let mut selected_text = None;
 
                 let _ = this.editor.update(cx, |this, cx| {
@@ -113,15 +117,16 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.command_bar.update(cx, |this, cx| {
+        self.command_bar.clone().update(cx, |this, cx| {
             this.is_toggled = !this.is_toggled;
 
             // Manually shift the focus, otherwise it won't just focus automatically
             if !this.is_toggled {
-                window.focus(&self.focus_handle(cx));
+                self.return_focus(window);
             }
 
             if this.is_toggled {
+                self.advance_focus(window, cx);
                 window.focus(&this.get_input_field_focus_handle(cx));
             }
         });

--- a/crates/opennote-desktop/src/views/workspace/mod.rs
+++ b/crates/opennote-desktop/src/views/workspace/mod.rs
@@ -30,6 +30,11 @@ pub struct Workspace {
     pub search_bar: Entity<SearchBar>,
     pub settings_panel: Entity<SettingsPanel>,
 
+    /// Store the previous focus.
+    /// Useful when closing an UI component,
+    /// and restoring the focus to a preivous one.
+    pub previous_focuses: Vec<FocusHandle>,
+
     _subscriptions: Vec<Subscription>,
 }
 
@@ -88,7 +93,8 @@ impl Workspace {
         }));
 
         Ok(Self {
-            focus_handle,
+            focus_handle: focus_handle.clone(),
+            previous_focuses: Vec::new(),
             sidebar: sidebar.clone(),
             pane,
             command_bar: cx.new(|cx| CommandBar::new(cx, window)),
@@ -96,6 +102,24 @@ impl Workspace {
             settings_panel: cx.new(|cx| SettingsPanel::new(cx, window, sidebar.downgrade())),
             _subscriptions,
         })
+    }
+
+    /// Return the focus to a previous UI component.
+    pub fn return_focus(&mut self, window: &mut Window) {
+        // Return to the previously stored focus.
+        // Focus on Workspace if nothing remained.
+        match self.previous_focuses.pop() {
+            Some(handle) => window.focus(&handle),
+            None => window.focus(&self.focus_handle),
+        }
+    }
+
+    /// Add new focus to the focus list.
+    pub fn advance_focus(&mut self, window: &mut Window, cx: &App) {
+        match window.focused(cx) {
+            Some(result) => self.previous_focuses.push(result),
+            None => {}
+        }
     }
 }
 

--- a/crates/opennote-desktop/src/widgets/editor/mod.rs
+++ b/crates/opennote-desktop/src/widgets/editor/mod.rs
@@ -31,6 +31,7 @@ pub struct Editor {
     focus_handle: FocusHandle,
     pub state: Entity<opennote_velotype::editor::Editor>,
 
+    focus_requested: bool,
     pub highlighted_text: Option<SharedString>,
     pub block: Option<Block>,
     loaded_block_id: Option<Uuid>,
@@ -63,6 +64,7 @@ impl Editor {
             loaded_block_id: None,
             pane,
             _subscriptions,
+            focus_requested: false,
         }
     }
 
@@ -172,6 +174,12 @@ impl Editor {
         });
         self.apply_highlighted_text(cx);
     }
+
+    /// Request the editor to focus itself
+    pub fn request_editor_to_focus(&mut self, cx: &mut Context<Self>) {
+        self.focus_requested = true;
+        cx.notify();
+    }
 }
 
 impl Focusable for Editor {
@@ -189,6 +197,14 @@ impl Render for Editor {
         cx: &mut gpui::Context<Self>,
     ) -> impl gpui::IntoElement {
         self.update_editor_content_with_new_block(cx);
+
+        // On re-rendering, this will read the `self.focus_requested` var for whether the focus will be transfered.
+        // The `request_editor_to_focus` is made by a call site, so the call site decide whether to focus.
+        if std::mem::take(&mut self.focus_requested) {
+            self.state.update(cx, |this, cx| {
+                this.request_focus(cx);
+            });
+        }
 
         div()
             .key_context(EDITOR)

--- a/crates/opennote-desktop/src/widgets/pane/helpers.rs
+++ b/crates/opennote-desktop/src/widgets/pane/helpers.rs
@@ -14,6 +14,11 @@ pub fn open_block(cx: &mut App, block_id: Uuid, highlighted_text: Option<SharedS
     let _ = active_pane.update(cx, |this, cx| {
         this.set_selected_block_by_block_id(block_id, cx);
 
+        // Request the editor to focus itself after opening the block.
+        this.editor.update(cx, |this, cx| {
+            this.request_editor_to_focus(cx);
+        });
+
         if let Some(string) = highlighted_text {
             this.set_search_string(string.clone());
             cx.notify();

--- a/crates/opennote-desktop/src/widgets/sidebar/mod.rs
+++ b/crates/opennote-desktop/src/widgets/sidebar/mod.rs
@@ -47,6 +47,8 @@ pub enum OpenNoteSidebarEvent {
 pub struct OpenNoteSidebar {
     focus_handle: FocusHandle,
     is_toggled: bool,
+
+    // Store tree structure's states
     tree_states: HashMap<SharedString, Entity<TreeState>>,
 
     // Store blocks' UI states, like expansion

--- a/crates/opennote-velotype/src/editor/runtime_context.rs
+++ b/crates/opennote-velotype/src/editor/runtime_context.rs
@@ -3,6 +3,14 @@
 use super::*;
 
 impl Editor {
+    /// A public method for requesting the Velotype editor to transfer the focus.
+    pub fn request_focus(&mut self, cx: &mut Context<Self>) {
+        if let Some(entity_id) = self.current_edit_target_entity_id_from_state(cx) {
+            self.focus_block(entity_id);
+            cx.notify();
+        }
+    }
+
     pub(super) fn current_edit_target_entity_id_from_state(&self, cx: &App) -> Option<EntityId> {
         self.active_entity_id
             .filter(|entity_id| self.focusable_entity_by_id(*entity_id).is_some())


### PR DESCRIPTION
- Track and restore previous focus when closing sidebar, search bar, and command bar.
- Focus the editor after opening a block via request_editor_to_focus and velotype Editor::request_focus.
- Clone entity handles in workspace toggles to avoid borrow conflicts while updating focus.